### PR TITLE
build: rename start:dev to start:watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,10 +122,10 @@ The first results:
 NODE_ENV=dev npm run start
 ```
 
-### With auto realod (for development)
+### With hot realod (for development)
 
 ```bash
-NODE_ENV=dev npm run start:dev
+NODE_ENV=dev npm run start:watch
 ```
 
 ## Further Steps

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Dante's Divina Commedia on ElasticSearch",
   "main": "index.js",
   "scripts": {
-    "start:dev": "nodemon src/index.ts",
+    "start:watch": "nodemon src/index.ts",
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "rimraf ./build && tsc",
     "start": "npm run build && node -r config build/index.js",


### PR DESCRIPTION
More consistent and clear,
also avoids confusion with NODE_ENV=env